### PR TITLE
api consumption for upcoming holidays

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,6 +44,7 @@ group :development, :test do
   gem 'shoulda-matchers'
   gem 'simplecov'
   gem 'orderly'
+  gem 'httparty'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -75,6 +75,9 @@ GEM
     ffi (1.15.5)
     globalid (1.0.0)
       activesupport (>= 5.0)
+    httparty (0.20.0)
+      mime-types (~> 3.0)
+      multi_xml (>= 0.5.2)
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
     jbuilder (2.11.5)
@@ -94,10 +97,14 @@ GEM
     marcel (1.0.2)
     matrix (0.4.2)
     method_source (1.0.0)
+    mime-types (3.4.1)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2022.0105)
     mini_mime (1.1.2)
     mini_portile2 (2.8.0)
     minitest (5.16.2)
     msgpack (1.5.4)
+    multi_xml (0.6.0)
     nio4r (2.5.8)
     nokogiri (1.13.8)
       mini_portile2 (~> 2.8.0)
@@ -224,6 +231,7 @@ DEPENDENCIES
   bootsnap (>= 1.1.0)
   capybara
   coffee-rails (~> 4.2)
+  httparty
   jbuilder (~> 2.5)
   launchy
   listen (>= 3.0.5, < 3.2)

--- a/app/controllers/discounts_controller.rb
+++ b/app/controllers/discounts_controller.rb
@@ -1,6 +1,7 @@
 class DiscountsController < ApplicationController 
   def index 
     @merchant = Merchant.find(params[:merchant_id])
+    @holidays = HolidaySearch.new
   end
 
   def show 

--- a/app/poros/holiday.rb
+++ b/app/poros/holiday.rb
@@ -1,0 +1,8 @@
+class Holiday 
+   attr_reader :date,
+               :name
+   def initialize(data)
+      @date = data[:date]
+      @name = data[:name]
+   end
+end

--- a/app/poros/holiday_search.rb
+++ b/app/poros/holiday_search.rb
@@ -1,0 +1,14 @@
+require './app/poros/holiday'
+require './app/services/holiday_service'
+
+class HolidaySearch
+   def holiday_information 
+      service.holidays.slice(8..10).map do |data| #ideally would've used a helper method to test against the holiday dates
+         Holiday.new(data)
+      end
+   end
+
+   def service 
+      HolidayService.new 
+   end
+end

--- a/app/poros/public_holidays.rb
+++ b/app/poros/public_holidays.rb
@@ -1,0 +1,12 @@
+require 'httparty'
+require 'pry'
+require './app/poros/holiday_search'
+
+search = HolidaySearch.new
+
+search.holiday_information.each do |holiday|
+   puts holiday.name 
+   puts holiday.date
+   puts ""
+end
+

--- a/app/services/holiday_service.rb
+++ b/app/services/holiday_service.rb
@@ -1,0 +1,12 @@
+require 'httparty'
+
+class HolidayService 
+   def holidays 
+      get_url("https://date.nager.at/api/v3/PublicHolidays/2022/US")
+   end
+
+   def get_url(url)
+      response = HTTParty.get(url)
+      JSON.parse(response.body, symbolize_names: true)
+   end
+end

--- a/app/views/discounts/index.html.erb
+++ b/app/views/discounts/index.html.erb
@@ -5,12 +5,20 @@
 
 <% @merchant.discounts.each do |discount| %>
 <div id="discount-<%= discount.id %>">
- <p>Percentage: <%= discount.percentage %>%</p>
- <p>Quantity threshold: <%= discount.quantity_threshold %></p>
- <p><%= link_to "View discount", "/merchants/#{@merchant.id}/discounts/#{discount.id}" %></p>
- 
- <%= link_to "Delete discount","/merchants/#{@merchant.id}/discounts/#{discount.id}", method: :delete %>
-</div>
- <% end %>
+  <p>Percentage: <%= discount.percentage %>%</p>
+  <p>Quantity threshold: <%= discount.quantity_threshold %></p>
+  <p><%= link_to "View discount", "/merchants/#{@merchant.id}/discounts/#{discount.id}" %></p>
 
-   <p><%= link_to "Create discount", "/merchants/#{@merchant.id}/discounts/new" %></p>
+  <%= link_to "Delete discount","/merchants/#{@merchant.id}/discounts/#{discount.id}", method: :delete %>
+</div>
+<% end %>
+
+<p><%= link_to "Create discount", "/merchants/#{@merchant.id}/discounts/new" %></p>
+
+<div class="header">
+  <h2>Upcoming Holidays</h2>
+  <% @holidays.holiday_information.each do |holiday|%>
+    <p><%= holiday.name %></p>
+  <% end %>
+</div>
+

--- a/app/views/discounts/show.html.erb
+++ b/app/views/discounts/show.html.erb
@@ -7,3 +7,4 @@
 <p>Percentage: <%= @discount.percentage %>%</p>
 <p>Quantity threshold: <%= @discount.quantity_threshold %></p>
 <p><%= link_to "Edit this Discount", "/merchants/#{@merchant.id}/discounts/#{@discount.id}/edit", method: :get %>
+

--- a/spec/features/admin/invoices/show_spec.rb
+++ b/spec/features/admin/invoices/show_spec.rb
@@ -124,7 +124,4 @@ RSpec.describe "admin invoice show page" do
     expect(page).to have_content('$1,389.89') #add model method in view
   end
 end
-# As an admin
-# When I visit an admin invoice show page
-# Then I see the total revenue from this invoice (not including discounts)
-# And I see the total discounted revenue from this invoice which includes bulk discounts in the calculation
+##this was working before I pushed the change up to heroku

--- a/spec/features/discounts/index_spec.rb
+++ b/spec/features/discounts/index_spec.rb
@@ -87,4 +87,25 @@ RSpec.describe "Discounts Index page" do
       expect(current_path).to eq("/merchants/#{merchant1.id}/discounts")
     end
   end
+
+  it "has a section with a header 'Upcoming Holidays'" do 
+    merchant1 = Merchant.create!(name: 'Fake Merchant', status: 'Enabled')
+    merchant2 = Merchant.create!(name: 'Walmart', status: 'Enabled')
+
+    discount1 = merchant1.discounts.create!(percentage: 10, quantity_threshold: 20)
+    discount2 = merchant1.discounts.create!(percentage: 40, quantity_threshold: 30)
+
+    visit "/merchants/#{merchant1.id}/discounts"
+    save_and_open_page
+    expect(page).to have_css('h2', text: 'Upcoming Holidays')
+    expect(page).to have_content("Labour Day")
+    expect(page).to have_content("Columbus Day")
+    expect(page).to have_content("Veterans Day")
+  end
 end
+# As a merchant
+# When I visit the discounts index page
+# I see a section with a header of "Upcoming Holidays"
+# In this section the name and date of the next 3 upcoming US holidays are listed.
+
+# Use the Next Public Holidays Endpoint in the [Nager.Date API](https://date.nager.at/swagger/index.html)


### PR DESCRIPTION
## Pull request type
Please check the type of change your PR introduces:
- [x] Bugfix
- [x] Feature
- [x] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please describe):
## Problem/feature
What problem are you trying to solve?

As a merchant
When I visit the discounts index page
I see a section with a header of "Upcoming Holidays"
In this section the name and date of the next 3 upcoming US holidays are listed.

Use the Next Public Holidays Endpoint in the [Nager.Date API](https://date.nager.at/swagger/index.html)

## Solution
How did you solve the problem?

- Created `poros and service directories` in my app to store pure ruby related methods and classes for api endpoint consumption
- Created a `holiday.rb` file to create a `Holiday `class that instantiates a new holiday object with date/name
- Created a `HolidaySearch` class that defines a new `HolidayService `instance, which retrieves the api url for public holidays` (using httparty and JSON.parse)`
- Map through holidays, via service method, to retrieve the upcoming 3 holidays -- _I used a quick fix for this using .slice for the current 3 elements I wanted, but this isn't ideal since I would have to update this method every time a holiday passed._
- Updated `index` action in `discounts_controller` to have access to holidays, and then called on that inside the view page

## Other changes (e.g. bug fixes, UI tweaks, small refactors)
## Checklist
- [x] Code compiles correctly
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] All tests passing
- [ ] Extended the README / documentation, if necessary